### PR TITLE
adding a more restrictive file listing for the renaming in download_d1_data

### DIFF
--- a/R/download_d1_data.R
+++ b/R/download_d1_data.R
@@ -162,9 +162,10 @@ download_d1_data <- function(data_obj, path) {
   message("Download complete")
   
   # change downloaded data object name to data_name
-  data_obj <- list.files(new_dir, full.names = TRUE)
-  data_obj_ext <- stringr::str_extract("filename.csv", ".[^.]{2,4}$")
-  file.rename(data_obj, file.path(new_dir, paste0(data_name, data_obj_ext)))
+  data_files <- list.files(new_dir, pattern = ".csv$", full.names = TRUE)
+  data_files <- data_files[!grepl(pattern='_metadata.csv', data_files)]
+  data_files_ext <- stringr::str_extract(data_files, ".[^.]{2,4}$")
+  file.rename(data_files, file.path(new_dir, paste0(data_name, data_files_ext)))
   
   ## write metadata xml/tabular form if exists
   if(exists("xml")) {

--- a/inst/testing_download.R
+++ b/inst/testing_download.R
@@ -48,7 +48,7 @@ map2(data_listing$pid, data_folder, download_d1_data)
 # List the data set folders
 local_datasets <- dir(data_folder, full.names = TRUE)
 
-# Read them all in as a names list (probably not the way scientisits want to do it)
+# Read them all in as a named list (probably not the way scientisits want to do it)
 test <- setNames(map(local_datasets, read_d1_files), basename(local_datasets))
 
 


### PR DESCRIPTION
- replaced the test"filename.csv"
- added condition to be sure we rename only the data file in case some other files are already in the folder