### PR TITLE
updated readme url example to same dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To download a data object, specify the data object URL and local download path i
 ```
 library(metajam)
 
-download_d1_data("https://arcticdata.io/metacat/d1/mn/v2/object/urn%3Auuid%3Ac102bac4-a5ea-4699-bfec-8d4ba60948d8", path = ".")
+download_d1_data("https://arcticdata.io/metacat/d1/mn/v2/object/urn%3Auuid%3A9e123f84-ce0d-4094-b898-c9e73680eafa", path = ".")
 ```
 <br>
 <img src="inst/images/download-output.png" width="60%"/>


### PR DESCRIPTION
updated readme:
- switched the URL used for the `download_d1_data` to the same as the `read_d1_files`

Need to create an example/vignette for the encoding issues that #56  and #62 highlighted with previous link