### PR TITLE
MM: Add extension to directory

### DIFF
--- a/R/download_d1_data.R
+++ b/R/download_d1_data.R
@@ -148,10 +148,11 @@ download_d1_data <- function(data_url, path) {
   
   data_name <- data_sys@fileName %|||% ifelse(exists("entity_data"), entity_data$physical$objectName %|||% entity_data$entityName, NA) %|||% data_id
   data_name <- gsub("[^a-zA-Z0-9. -]+", "_", data_name) #remove special characters & replace with _
-  data_name <- gsub("[.][a-zA-Z0-9]{2,4}$", "", data_name) #remove extension
+  data_extension <- gsub("(.*\\.)([^.]*$)", "\\2", data_name)
+  data_name <- gsub("\\.[^.]*$", "", data_name) #remove extension
   meta_name <- gsub("[^a-zA-Z0-9. -]+", "_", meta_id) #remove special characters & replace with _
   
-  new_dir <- file.path(path, paste0(meta_name, "__", data_name)) 
+  new_dir <- file.path(path, paste0(meta_name, "__", data_name, "__", data_extension)) 
   
   # Check if the dataset has already been downloaded at this location. If so, exit the function
   if (dir.exists(new_dir)) {


### PR DESCRIPTION
There seems to be frequent instances of files named the same in packages.
i.e. file.csv and file.xls
Without the file extension in the directory name, download_d1_data_pkg cannot download both files.