### PR TITLE
Fix file extension bug

### DIFF
--- a/R/download_d1_data.R
+++ b/R/download_d1_data.R
@@ -168,7 +168,7 @@ download_d1_data <- function(data_url, path) {
   
   # change downloaded data object name to data_name
   data_files <- list.files(new_dir, full.names = TRUE)
-  data_files_ext <- stringr::str_extract(data_files, ".[^.]{2,4}$")
+  data_files_ext <- stringr::str_extract(data_files, ".[^.]{1,4}$")
   file.rename(data_files, file.path(new_dir, paste0(data_name, data_files_ext)))
   
   entity_meta_general <- list(File_Name = data_name,


### PR DESCRIPTION
For files with one character file extensions, like R scripts ("script.R"), the `download_d1_data()` function returns a missing file extension for the file when downloaded ("scriptNA"). This can be fixed by simply expanding the lower limit on the number of characters in a file extension to 1.