### PR TITLE
Accept EDI and LTER data package inputs

### DIFF
--- a/R/get_pkg_pids.R
+++ b/R/get_pkg_pids.R
@@ -42,6 +42,12 @@ get_pkg_pids <- function(pkg_doi) {
                        fl = "identifier, formatType", rows = 10000)
   pids <- dataone::query(dataone::CNode(), query_params, as = "data.frame")
 
+  # Remove EDI data package evaluation reports since they are not "DATA".
+  # Including them as "DATA" results in errors.
+  pids <- pids[
+    !(stringr::str_detect(pids$identifier, 'pasta.lternet.edu') &
+      stringr::str_detect(pids$identifier, 'report')), ]
+
   # Create the list
   pid_list <- list(resource_map = rm_pid,
                    metadata = pids$identifier[pids$formatType == "METADATA"],

--- a/tests/testthat/test-download_d1_data_pkg.R
+++ b/tests/testthat/test-download_d1_data_pkg.R
@@ -9,3 +9,21 @@ test_that("accepts correct inputs", {
   expect_error(download_d1_data_pkg("test", ""))
   expect_error(download_d1_data_pkg("test", "test"))
 })
+
+test_that("accepts EDI data package", {
+  output <- download_d1_data_pkg(
+    meta_obj = 'doi:10.6073/pasta/9f2f89e48f9e943f7125d1a335d96eb0',
+    path = tempdir()
+  )
+  expect_true(dir.exists(output[[1]]))
+  unlink(output, recursive = TRUE)
+})
+
+test_that("accepts Arctic Data Center data package", {
+  output <- download_d1_data_pkg(
+    meta_obj = 'doi:10.18739/A2DP3X',
+    path = tempdir()
+  )
+  expect_true(dir.exists(output[[1]]))
+  unlink(output, recursive = TRUE)
+})

--- a/tests/testthat/test-get_pkg_pids.R
+++ b/tests/testthat/test-get_pkg_pids.R
@@ -1,0 +1,13 @@
+context("get_pkg_pids()")
+
+test_that('data package report is not "data"', {
+  output <- suppressMessages(
+    get_pkg_pids(
+      pkg_doi = 'https://doi.org/10.6073/pasta/08abf45e6ef1585ad7ee1e00fb9d7dc1'
+    )
+  )
+  expect_true(
+    !any(stringr::str_detect(output$data, 'report'))
+  )
+})
+

--- a/tests/testthat/test-read_d1_files.R
+++ b/tests/testthat/test-read_d1_files.R
@@ -22,3 +22,56 @@ test_that("test read in csv files", {
   expect_true(is.data.frame(pkg$summary_metadata))
   expect_true(is.data.frame(pkg$data))
 })
+
+test_that("read Arctic Data Center data package", {
+  # Call download_di_data_pkg() for data package
+  paths <- suppressMessages(
+    download_d1_data_pkg(
+      meta_obj = 'doi:10.18739/A2DP3X',
+      path = tempdir()
+    )
+  )
+  # Read data and metadata
+  output <- suppressMessages(
+    read_d1_files(
+      folder_path = paths[[2]]
+    )
+  )
+  # Test output class
+  expect_true(class(output) == 'list')
+  # Test output list object names
+  expect_true(
+    all(
+      names(output) %in% c('attribute_metadata', 'summary_metadata', 'data', 'factor_metadata')
+    )
+  )
+  # Clean up
+  unlink(paths, recursive = TRUE)
+})
+
+
+test_that("read EDI data package", {
+  # Call download_di_data_pkg() for data package
+  paths <- suppressMessages(
+    download_d1_data_pkg(
+      meta_obj = 'doi:10.6073/pasta/9f2f89e48f9e943f7125d1a335d96eb0',
+      path = tempdir()
+    )
+  )
+  # Read data and metadata
+  output <- suppressMessages(
+    read_d1_files(
+      folder_path = paths[[1]]
+    )
+  )
+  # Test output class
+  expect_true(class(output) == 'list')
+  # Test output list object names
+  expect_true(
+    all(
+      names(output) %in% c('attribute_metadata', 'summary_metadata', 'data')
+    )
+  )
+  # Clean up
+  unlink(paths, recursive = TRUE)
+})


### PR DESCRIPTION
The functions download_d1_data_pkg() and read_d1_files() don't accept EDI and LTER data packages as inputs. This issue arises from a misidentification of EDI and LTER data package reports (.xml) as "DATA" pid identifiers. This enhancement removes data package reports from the list of pid identifiers and allows the package contents to pass without error.