### PR TITLE
Fix Windows path in read_d1_files()

### DIFF
--- a/R/read_d1_files.R
+++ b/R/read_d1_files.R
@@ -46,7 +46,7 @@ read_d1_files <- function(folder_path, fnc = "read_csv", ...) {
     if (grepl("[^_]+_metadata(?=\\.csv)", basename(x), perl = TRUE)) {
       readr::read_csv(x)
     } else if (tools::file_path_sans_ext(basename(x)) == filename) {
-      eval(parse(text = paste0(fnc, '("', x, '", ...)')))
+      eval(parse(text = paste0(fnc, '("', normalizePath(x, winslash = '/'), '", ...)')))
     }
   })
 


### PR DESCRIPTION
We found extraneous escape characters that implied hex code when eval(parse(text = ...)) fixed by forcing forward slash in file name for one line.