### PR TITLE
Allow user to name directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@
 language: r
 sudo: true
 cache: packages
+
+warnings_are_errors: false
+
 addons:
   apt:
     sources:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,4 +38,4 @@ Suggests:
 Encoding: UTF-8
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2

--- a/R/download_d1_data.R
+++ b/R/download_d1_data.R
@@ -30,7 +30,7 @@
 #'     )
 #' }
 
-download_d1_data <- function(data_url, path) {
+download_d1_data <- function(data_url, path, dir_name = NULL) {
   # TODO: add meta_doi to explicitly specify doi
 
   stopifnot(is.character(data_url), length(data_url) == 1, nchar(data_url) > 0)
@@ -160,15 +160,47 @@ download_d1_data <- function(data_url, path) {
   data_name <- gsub("\\.[^.]*$", "", data_name) #remove extension
   meta_name <- gsub("[^a-zA-Z0-9. -]+", "_", meta_id) #remove special characters & replace with _
 
-  new_dir <- file.path(path, paste0(meta_name, "__", data_name, "__", data_extension))
+  # Check for backwards compatability.
+  old_dir_path <- file.path(path, paste0(meta_name, "__", data_name, "__", data_extension))
 
-  # Check if the dataset has already been downloaded at this location. If so, exit the function
-  if (dir.exists(new_dir)) {
-    warning("This dataset has already been downloaded. Please delete or move the folder to download the dataset again.")
+  log_path <- file.path(path, "metajam_log")
+  old_dataid <- ""
+
+  # Check to see if log exists (ie data has been download at this location).
+    # If it does, then get the version number downloaded, and save it into old_dataid
+  if(file.exists(log_path)){
+    old_log <- suppressMessages(readr::read_csv(log_path))
+    old_dataid <- old_log %>%
+      tail(1) %>%
+      dplyr::pull(Data_ID)
+    old_dir_path <- old_log %>%
+      tail(1) %>%
+      dplyr::pull(Location)
+  }
+
+  # If the latest version is already downloaded, then exit the function
+    # first condition checks old naming scheme, second condition checks log (so folder can have any name)
+  if(dir.exists(old_dir_path) | old_dataid == data_id){
+    warning(paste("This dataset has already been downloaded here:", old_dir_path, "Please delete or move the folder to download the dataset again.", sep = "\n"))
     return(new_dir)
   }
 
-  dir.create(new_dir)
+  # Name the new folder, checking for optional parameter dir_name
+  if(!is.null(dir_name)){
+    new_dir <- file.path(path, dir_name)
+  } else {
+    new_dir <- file.path(path, paste0(data_name, "__", data_extension))
+  }
+
+  # Check to make sure we don't overwrite old versions of the data.
+    # If the directory they're trying to create already exists, then exit the function.
+  if(dir.exists(new_dir)){
+    warning(paste("An old version of the data exists at the specified path:", new_dir, "Please change dir_name or delete/move the folder to download a new version of the data", sep = "\n"))
+    return(new_dir)
+  } else{
+    dir.create(new_dir)
+  }
+
 
   ## download Data
   out <- dataone::downloadObject(d1c, data_id, path = new_dir)
@@ -189,11 +221,11 @@ download_d1_data <- function(data_url, path) {
   if (exists("eml")) {
     EML::write_eml(eml, file.path(new_dir, paste0(data_name, "__full_metadata.xml")))
 
-    entity_meta_combined <- c(entity_meta_general, entity_meta) %>% unlist() %>% enframe()
+    entity_meta_combined <- c(entity_meta_general, entity_meta) %>% unlist() %>% tibble::enframe()
     readr::write_csv(entity_meta_combined,
                      file.path(new_dir, paste0(data_name, "__summary_metadata.csv")))
   } else {
-    entity_meta_general <- entity_meta_general %>% unlist() %>% enframe()
+    entity_meta_general <- entity_meta_general %>% unlist() %>% tibble::enframe()
     readr::write_csv(entity_meta_general,
                      file.path(new_dir, paste0(data_name, "__summary_metadata.csv")))
   }
@@ -201,16 +233,29 @@ download_d1_data <- function(data_url, path) {
   # write attribute tables if data metadata exists
   if (exists("attributeList")) {
     if (nrow(attributeList$attributes) > 0) {
-      atts <- attributeList$attributes %>% mutate(metadata_pid = meta_id)
+      atts <- attributeList$attributes %>% dplyr::mutate(metadata_pid = meta_id)
       readr::write_csv(atts,
                        file.path(new_dir, paste0(data_name, "__attribute_metadata.csv")))
     }
 
     if (!is.null(attributeList$factors)) {
-      facts <- attributeList$factors %>% mutate(metadata_pid = meta_id)
+      facts <- attributeList$factors %>% dplyr::mutate(metadata_pid = meta_id)
       readr::write_csv(facts,
                        file.path(new_dir, paste0(data_name, "__attribute_factor_metadata.csv")))
     }
+  }
+
+
+  # Write to log file (log file's name and path is log_path)
+  data_to_log <- data.frame(Date_Run = paste0(Sys.time()),
+                            Data_ID = data_id,
+                            Dataset_URL = data_nodes$data$url,
+                            Location = new_dir)
+
+  if(file.exists(log_path)){
+    readr::write_csv(data_to_log, path = log_path, append = TRUE)
+  } else {
+    readr::write_csv(data_to_log, path = log_path, append = FALSE, col_names = TRUE)
   }
 
   ## Output folder name

--- a/R/download_d1_data.R
+++ b/R/download_d1_data.R
@@ -4,6 +4,7 @@
 #'
 #' @param data_url (character) An identifier or URL for a DataONE object to download.
 #' @param path (character) Path to a directory to download data to.
+#' @param dir_name (character) (Optional) Desired name for the folder containing the downloaded data. Defaults to the data file name.
 #'
 #' @return (character) Path where data is downloaded to.
 #'

--- a/R/download_d1_data.R
+++ b/R/download_d1_data.R
@@ -29,19 +29,7 @@
 #'     path = "."
 #'     )
 #' }
-
-
-# trying to download the same dataset twice (can do the second time with dir_name = "dummy_name")
-download_d1_data(data_url = "https://cn.dataone.org/cn/v2/resolve/urn:uuid:a2834e3e-f453-4c2b-8343-99477662b570",
-                 path = file.path("/Users/nathan/Desktop/testing"),
-                 dir_name = "not_really_new"
-                 )
-
-# downloading an outdated version -> the right version
-download_d1_data(data_url = "https://cn.dataone.org/cn/v2/resolve/cbfs.21.6",
-                 path = file.path("/Users/nathan/Desktop/testing"),
-                 dir_name = "outdated")
-
+#'
 
 download_d1_data <- function(data_url, path, dir_name = NULL) {
   # TODO: add meta_doi to explicitly specify doi
@@ -176,7 +164,7 @@ download_d1_data <- function(data_url, path, dir_name = NULL) {
   # Check for backwards compatability.
   old_dir_path <- file.path(path, paste0(meta_name, "__", data_name, "__", data_extension))
 
-  log_path <- file.path(path, "metajam_log")
+  log_path <- file.path(path, "metajam.log")
   old_dir_path_log <- ""
 
   # Check to see if log exists (ie some data has been download at this location).
@@ -266,6 +254,7 @@ download_d1_data <- function(data_url, path, dir_name = NULL) {
                             Dataset_URL = data_nodes$data$url,
                             Location = new_dir)
 
+  # If the log file doesn't exist yet, then create it.
   if(file.exists(log_path)){
     readr::write_csv(data_to_log, path = log_path, append = TRUE)
   } else {

--- a/man/download_d1_data.Rd
+++ b/man/download_d1_data.Rd
@@ -4,12 +4,14 @@
 \alias{download_d1_data}
 \title{Download data and metadata from DataONE}
 \usage{
-download_d1_data(data_url, path)
+download_d1_data(data_url, path, dir_name = NULL)
 }
 \arguments{
 \item{data_url}{(character) An identifier or URL for a DataONE object to download.}
 
 \item{path}{(character) Path to a directory to download data to.}
+
+\item{dir_name}{(character) (Optional) Desired name for the folder containing the downloaded data. Defaults to the data file name.}
 }
 \value{
 (character) Path where data is downloaded to.
@@ -25,6 +27,7 @@ download_d1_data(
     path = "."
     )
 }
+
 }
 \seealso{
 \code{\link[=read_d1_files]{read_d1_files()}} \code{\link[=download_d1_data_pkg]{download_d1_data_pkg()}}

--- a/man/metajam.Rd
+++ b/man/metajam.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{metajam}
 \alias{metajam}
-\alias{metajam-package}
 \title{\code{metajam} package}
 \description{
 Metadata jam - bringing data and metadata together

--- a/tests/testthat/test-download_d1_data.R
+++ b/tests/testthat/test-download_d1_data.R
@@ -22,7 +22,7 @@ test_that("test Arctic Data Center data URL (fully up to date data file)", {
   expect_true(any(stringr::str_detect(files, "summary_metadata.csv")))
 
   folder_name <- stringr::str_extract(out, "[^/]*$")
-  expect_true(stringr::str_detect(folder_name, "^doi")) #starts with doi
+  expect_true(any(stringr::str_detect(list.files(temp_dir), "metajam.log")))
 
   # remove files
   file.remove(list.files(out, recursive = TRUE, full.names = TRUE))
@@ -41,7 +41,7 @@ test_that("test Arctic Data Center data URL (fully up to date data file) with on
   expect_true(any(stringr::str_detect(files, "summary_metadata.csv")))
 
   folder_name <- stringr::str_extract(out, "[^/]*$")
-  expect_true(stringr::str_detect(folder_name, "^doi")) #starts with doi
+  expect_true(any(stringr::str_detect(list.files(temp_dir), "metajam.log")))
 
   # remove files
   file.remove(list.files(out, recursive = TRUE, full.names = TRUE))
@@ -61,7 +61,7 @@ test_that("test Arctic Data Center data URL (fully up to date data file) with mu
   expect_true(any(stringr::str_detect(files, "summary_metadata.csv")))
 
   folder_name <- stringr::str_extract(out, "[^/]*$")
-  expect_true(stringr::str_detect(folder_name, "^doi")) #starts with doi
+  expect_true(any(stringr::str_detect(list.files(temp_dir), "metajam.log")))
 
   # remove files
   file.remove(list.files(out, recursive = TRUE, full.names = TRUE))
@@ -81,4 +81,49 @@ test_that("Data without metadata downloads and returns summary metadata", {
   file.remove(list.files(out, recursive = TRUE, full.names = TRUE))
   file.remove(out)
 })
+
+test_that("Downloading same data with different foldername (dir_name) returns error",{
+  temp_dir <- tempdir()
+
+  # first download. should run correctly
+  out <- download_d1_data(data_url = "https://cn.dataone.org/cn/v2/resolve/urn:uuid:a2834e3e-f453-4c2b-8343-99477662b570",
+                   path = temp_dir,
+                   dir_name = "should_work")
+
+  # downloading same data under different name
+  expect_error(
+    download_d1_data(data_url = "https://cn.dataone.org/cn/v2/resolve/urn:uuid:a2834e3e-f453-4c2b-8343-99477662b570",
+                                      path = temp_dir,
+                                      dir_name = "should_fail")
+    )
+
+  # remove files
+  file.remove(list.files(out, recursive = TRUE, full.names = TRUE))
+  file.remove(out)
+})
+
+
+# # I couldn't think of what to test with the versions, but I wanted to save the links.
+# test_that("Downloading different versions of the data",{
+#   temp_dir <- tempdir()
+#
+#   # old version of data
+#   old_version <- download_d1_data("https://cn.dataone.org/cn/v2/resolve/cbfs.151.1",
+#                                path = file.path("/Users/nathan/Desktop/testing"),
+#                                dir_name = "old_kgordon")
+#
+#   # new version
+#   new_version <- download_d1_data("https://cn.dataone.org/cn/v2/resolve/cbfs.151.2",
+#                                path = file.path("/Users/nathan/Desktop/testing"),
+#                                dir_name = "newer_kgordon")
+#
+#
+#
+#   # remove files
+#   file.remove(list.files(old_version, recursive = TRUE, full.names = TRUE))
+#   file.remove(old_version)
+# })
+
+
+
 


### PR DESCRIPTION
Adds a `dir_name` argument to the `download_d1_data()` function, which allows the user to specify a name for the downloaded data folder.  If not specified, then `dir_name` will be a shortened version of the old naming system (ie we get rid of the doi/metadata id at the beginning). 

This helps fix the issue where sometimes folder names would be really long.

To keep track of the data, this also adds a `metajam.log` csv file to the working directory. `download_d1_data()` will read in this file to keep track of data versions without relying on folder names.

