### PR TITLE
Change default folder name to old naming system (ie include meta_name)

### DIFF
--- a/R/download_d1_data.R
+++ b/R/download_d1_data.R
@@ -192,7 +192,7 @@ download_d1_data <- function(data_url, path, dir_name = NULL) {
   if(!is.null(dir_name)){
     new_dir <- file.path(path, dir_name)
   } else {
-    new_dir <- file.path(path, paste0(data_name, "__", data_extension))
+    new_dir <- old_dir_path
   }
 
   # Check to make sure we don't overwrite old versions of the data.


### PR DESCRIPTION
In the first PR (#109), one of the changes we made was to shorten the default directory name. Here, we revert that change to make the transition easier for existing users.